### PR TITLE
Make sure create resource follow location header.

### DIFF
--- a/arsenalclient/common/base.py
+++ b/arsenalclient/common/base.py
@@ -215,6 +215,8 @@ class CreateManager(Manager):
                  'attrs': '","'.join(invalid)})
         url = self._path()
         resp, body = self.api.json_request('POST', url, body=new)
+        if resp.headers['location']:
+            resp, body = self.api.json_request('GET', resp.headers['location'])
         if body:
             return self.resource_class(self, body)
 

--- a/arsenalclient/tests/unit/v1/test_resource.py
+++ b/arsenalclient/tests/unit/v1/test_resource.py
@@ -53,8 +53,8 @@ fake_responses = {
             {"resource": [RESOURCE]},
         ),
         'POST': (
-            {},
-            CREATE_RESOURCE,
+            {'location': '/v1/resources/detail'},
+            {}
         ),
     },
     '/v1/resources/detail':
@@ -247,6 +247,7 @@ class ResourceManagerTest(testtools.TestCase):
         resource = self.mgr.create(**CREATE_RESOURCE)
         expect = [
             ('POST', '/v1/resources', {}, CREATE_RESOURCE),
+            ('GET', '/v1/resources/detail', {}, None),
         ]
         self.assertEqual(expect, self.api.calls)
         self.assertTrue(resource)
@@ -255,6 +256,16 @@ class ResourceManagerTest(testtools.TestCase):
         resource = self.mgr.create(**CREATE_WITH_UUID)
         expect = [
             ('POST', '/v1/resources', {}, CREATE_WITH_UUID),
+            ('GET', '/v1/resources/detail', {}, None),
+        ]
+        self.assertEqual(expect, self.api.calls)
+        self.assertTrue(resource)
+
+    def test_create_with_return(self):
+        resource = self.mgr.create(**CREATE_WITH_UUID)
+        expect = [
+            ('POST', '/v1/resources', {}, CREATE_WITH_UUID),
+            ('GET', '/v1/resources/detail', {}, None),
         ]
         self.assertEqual(expect, self.api.calls)
         self.assertTrue(resource)


### PR DESCRIPTION
~/git/python-arsenalclient$ .tox/py34/bin/arsenal --arsenal_url http://127.0.0.1:7777/ resource-create --type server -a ironic_driver=fake -a ram=100 -a cpu_count=2 -a cpu_cores=2 -a disk=100
+-------------+--------------------------------------------------------------------+
| Property    | Value                                                              |
+-------------+--------------------------------------------------------------------+
| attributes  | {'ironic_driver': 'fake', 'ram': 100, 'disk': 100, 'cpu_count': 2, |
|             | 'cpu_cores': 2}                                                    |
| description |                                                                    |
| type        | server                                                             |
| uuid        | 8f594039-4e84-46a3-9521-748cbc7dc598                               |
+-------------+--------------------------------------------------------------------+
