### PR TITLE
Make Resource list works

### DIFF
--- a/arsenalclient/tests/unit/v1/test_resource.py
+++ b/arsenalclient/tests/unit/v1/test_resource.py
@@ -50,7 +50,7 @@ fake_responses = {
     {
         'GET': (
             {},
-            {"resource": [RESOURCE]},
+            {"resources": [RESOURCE]},
         ),
         'POST': (
             {},
@@ -61,14 +61,14 @@ fake_responses = {
     {
         'GET': (
             {},
-            {"resource": [RESOURCE]},
+            {"resources": [RESOURCE]},
         ),
     },
     '/v1/resources/?fields=uuid,attributes':
     {
         'GET': (
             {},
-            {"resource": [RESOURCE]},
+            {"resources": [RESOURCE]},
         ),
     },
     '/v1/resources/%s' % RESOURCE['uuid']:
@@ -100,7 +100,7 @@ fake_responses_pagination = {
     {
         'GET': (
             {},
-            {"resource": [RESOURCE],
+            {"resources": [RESOURCE],
              "next": "http://127.0.0.1:6385/v1/resources/?limit=1"}
         ),
     },
@@ -108,14 +108,14 @@ fake_responses_pagination = {
     {
         'GET': (
             {},
-            {"resource": [RESOURCE2]}
+            {"resources": [RESOURCE2]}
         ),
     },
     '/v1/resources/?marker=%s' % RESOURCE['uuid']:
     {
         'GET': (
             {},
-            {"resource": [RESOURCE2]}
+            {"resources": [RESOURCE2]}
         ),
     },
 }
@@ -125,14 +125,14 @@ fake_responses_sorting = {
     {
         'GET': (
             {},
-            {"resource": [RESOURCE2]}
+            {"resources": [RESOURCE2]}
         ),
     },
     '/v1/resources/?sort_dir=desc':
     {
         'GET': (
             {},
-            {"resource": [RESOURCE2]}
+            {"resources": [RESOURCE2]}
         ),
     },
 }

--- a/arsenalclient/v1/resource.py
+++ b/arsenalclient/v1/resource.py
@@ -78,9 +78,9 @@ class ResourceManager(base.CreateManager):
             path += '?' + '&'.join(filters)
 
         if limit is None:
-            return self._list(self._path(path), "resource")
+            return self._list(self._path(path), "resources")
         else:
-            return self._list_pagination(self._path(path), "resource",
+            return self._list_pagination(self._path(path), "resources",
                                          limit=limit)
 
     def get(self, resource_id, fields=None):


### PR DESCRIPTION
The api returns a list of resource with the key 'resources' instead of
'resource'. This make the client support this new key.
